### PR TITLE
Fix /vault not being able to open the default vault

### DIFF
--- a/SherbetVaults/Commands/VaultCommand.cs
+++ b/SherbetVaults/Commands/VaultCommand.cs
@@ -39,11 +39,11 @@ namespace SherbetVaults.Commands
                 return;
             }
 
-            var vault = await Plugin.VaultManager.GetVault(context.PlayerID, targetVault);
+            var vault = await Plugin.VaultManager.GetVault(context.PlayerID, vaultConfig.VaultID);
 
             if (vault == null)
             {
-                await context.ReplyKeyAsync("Vault_Fail_CannotLoad", targetVault);
+                await context.ReplyKeyAsync("Vault_Fail_CannotLoad", vaultConfig.VaultID);
                 return;
             }
 


### PR DESCRIPTION
At the moment, the `/vault`-command will only use the `vaultConfig` to do a permission/availability look up. When actually loading the vault, it will fall back to the string provided by the user.

This means that the default (no argument to `/vault`) does not work since it will find the correct `vaultConfig`, but then fall back to use the empty string provided by the user.